### PR TITLE
migrated to Guava >= 15.0 and webarchive-commons 1.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>17.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.10</version>
@@ -126,6 +132,30 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+	      <relocations>
+		<relocation>
+		  <pattern>com.google</pattern>
+		  <shadedPattern>thirdparty.com.google</shadedPattern>
+		</relocation>
+	      </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+
     </plugins>
     <resources>
       <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,21 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>2.5.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.netpreserve.commons</groupId>
       <artifactId>webarchive-commons</artifactId>
       <version>1.1.5-SNAPSHOT</version>
       <scope>compile</scope>
+      <exclusions>
+	<exclusion>
+	  <groupId>com.google.protobuf</groupId>
+	  <artifactId>protobuf-java</artifactId>
+	</exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.archive.access-control</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.netpreserve.commons</groupId>
       <artifactId>webarchive-commons</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>1.1.5-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>17.0</version>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.10</version>
@@ -132,30 +126,6 @@
           </execution>
         </executions>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-	      <relocations>
-		<relocation>
-		  <pattern>com.google</pattern>
-		  <shadedPattern>thirdparty.com.google</shadedPattern>
-		</relocation>
-	      </relocations>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-
     </plugins>
     <resources>
       <resource>

--- a/src/main/java/org/archive/hadoop/jobs/ArchiveFileExtractor.java
+++ b/src/main/java/org/archive/hadoop/jobs/ArchiveFileExtractor.java
@@ -17,7 +17,6 @@
 package org.archive.hadoop.jobs;
 
 import com.google.common.io.ByteStreams;
-import com.google.common.io.LimitInputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -318,8 +317,7 @@ public class ArchiveFileExtractor extends Configured implements Tool {
    	     						w.write(new ByteArrayInputStream(header));
 							firstArcRecord = false;
 						}
-						LimitInputStream lis = new LimitInputStream(orig, length);
-						ByteStreams.copy(lis, currentArcOS);
+						ByteStreams.copy(ByteStreams.limit(orig, length), currentArcOS);
 					} else {
 						if(firstWarcRecord) {
 							String newWarcName = warcNamer.getNextName();
@@ -331,8 +329,7 @@ public class ArchiveFileExtractor extends Configured implements Tool {
            						w.write(new ByteArrayInputStream(header));
 							firstWarcRecord = false;
 						}
-						LimitInputStream lis = new LimitInputStream(orig, length);
-						ByteStreams.copy(lis, currentWarcOS);
+						ByteStreams.copy(ByteStreams.limit(orig, length), currentWarcOS);
 					}
 					output.collect("SUCCESS",offset + "\t" + url);
 				} catch (Exception e) {

--- a/src/main/java/org/archive/hadoop/pig/ZipNumRecordReader.java
+++ b/src/main/java/org/archive/hadoop/pig/ZipNumRecordReader.java
@@ -32,7 +32,7 @@ public class ZipNumRecordReader extends RecordReader<Text, Text> {
 	}
 
 	@Override
-	public float getProgress() {
+	public float getProgress() throws IOException {
 		return inner.getProgress();
 	}
 

--- a/src/main/java/org/archive/hadoop/streaming/ZipNumRecordReader.java
+++ b/src/main/java/org/archive/hadoop/streaming/ZipNumRecordReader.java
@@ -66,7 +66,7 @@ public class ZipNumRecordReader implements RecordReader<Text, Text> {
 	
 
 	@Override
-	public float getProgress() {
+	public float getProgress() throws IOException {
 		return inner.getProgress();
 	}
 

--- a/src/main/java/org/archive/server/FileBackedInputStream.java
+++ b/src/main/java/org/archive/server/FileBackedInputStream.java
@@ -23,7 +23,7 @@ public class FileBackedInputStream extends FilterInputStream {
 		return false;
 	}
 	public InputStream getInputStream() throws IOException {
-		return backer.getSupplier().getInput();
+		return backer.asByteSource().openStream();
 	}
 
 	public void resetBacker() throws IOException {

--- a/src/main/java/org/archive/server/GZRangeClient.java
+++ b/src/main/java/org/archive/server/GZRangeClient.java
@@ -30,7 +30,6 @@ import org.archive.util.IAUtils;
 import org.archive.util.DateUtils;
 import org.archive.util.FileNameSpec;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.LimitInputStream;
 
 public class GZRangeClient {
 
@@ -284,8 +283,7 @@ http-header-from: archive-crawler-agent@lists.sourceforge.net
 		if(currentWarcSize == 0) {
 			nextWarc();
 		}
-		LimitInputStream lis = new LimitInputStream(is, length);
-		ByteStreams.copy(lis, currentWarcOS);
+		ByteStreams.copy(ByteStreams.limit(is, length), currentWarcOS);
 		currentWarcSize += length;
 		if(currentWarcSize > maxWarcSize) {
 			closeWarc();
@@ -295,8 +293,7 @@ http-header-from: archive-crawler-agent@lists.sourceforge.net
 		if(currentArcSize == 0) {
 			nextArc();
 		}
-		LimitInputStream lis = new LimitInputStream(is, length);
-		ByteStreams.copy(lis, currentArcOS);
+		ByteStreams.copy(ByteStreams.limit(is, length), currentArcOS);
 		currentArcSize += length;
 		if(currentArcSize > maxArcSize) {
 			closeArc();

--- a/src/main/java/org/archive/server/GZRangeServer.java
+++ b/src/main/java/org/archive/server/GZRangeServer.java
@@ -24,7 +24,6 @@ import org.mortbay.jetty.Server;
 import org.mortbay.jetty.handler.AbstractHandler;
 
 import com.google.common.io.ByteStreams;
-import com.google.common.io.LimitInputStream;
 
 public class GZRangeServer extends AbstractHandler implements Tool {
 	public final static String TOOL_NAME = "gzrange-server";
@@ -161,9 +160,7 @@ public class GZRangeServer extends AbstractHandler implements Tool {
 							response.setContentType("application/octet-stream");
 							response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
 							response.setContentLength((int)gzLength);
-							LimitInputStream lis = 
-								new LimitInputStream(fis, gzLength);
-							long copied = ByteStreams.copy(lis,
+							long copied = ByteStreams.copy(ByteStreams.limit(fis, gzLength),
 									response.getOutputStream());
 							if(copied != gzLength) {
 								throw new IOException("Short copy Want(" +


### PR DESCRIPTION
This lets the project compile against webarchive-commons 1.1.5 which was not possible due to incompatibilities with a newer Guava version that was introduced by webarchive-commons 1.1.5. 

Nevertheless, the CDXGenerator still fails with errors (see my comment for the commit).
